### PR TITLE
Add gem version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/Sage/handler_registerable.svg?branch=master)](https://travis-ci.org/Sage/handler_registerable)
 [![Maintainability](https://api.codeclimate.com/v1/badges/aa4fce157655c3ee8497/maintainability)](https://codeclimate.com/github/Sage/handler_registerable/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/aa4fce157655c3ee8497/test_coverage)](https://codeclimate.com/github/Sage/handler_registerable/test_coverage)
+[![Gem Version](https://badge.fury.io/rb/handler_registerable.svg)](https://badge.fury.io/rb/handler_registerable)
 
 ## Description
 


### PR DESCRIPTION
Real reason for the PR is to trigger the CodeClimate coverage status check so we can make it required.